### PR TITLE
Prevent NullPointerException when getting OS name

### DIFF
--- a/src/main/java/com/github/couchmove/utils/Utils.java
+++ b/src/main/java/com/github/couchmove/utils/Utils.java
@@ -45,7 +45,8 @@ public class Utils {
                 Class<?> c = Class.forName(className);
                 Method method = c.getDeclaredMethod(methodName);
                 Object o = c.newInstance();
-                return method.invoke(o).toString();
+                Object name = method.invoke(o);
+                return name == null ? "unknown" : name.toString();
             } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
                 logger.error("Unable to get actual user name", e);
             }

--- a/src/main/java/com/github/couchmove/utils/Utils.java
+++ b/src/main/java/com/github/couchmove/utils/Utils.java
@@ -46,7 +46,9 @@ public class Utils {
                 Method method = c.getDeclaredMethod(methodName);
                 Object o = c.newInstance();
                 Object name = method.invoke(o);
-                return name == null ? "unknown" : name.toString();
+                if (name != null) {
+                    return name.toString();
+                }
             } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
                 logger.error("Unable to get actual user name", e);
             }


### PR DESCRIPTION
In some environments (ie: with OpenShift), username retrieved by the system is `null`. If this is the case, it should return "unknown" (same as with unknown OS name).