### PR TITLE
make ChangeLog version compatible with semver convention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,14 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>bintray</name>
+            <url>http://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -115,6 +123,11 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.8</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.g00fy2</groupId>
+            <artifactId>versioncompare</artifactId>
+            <version>1.3.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/couchmove/pojo/ChangeLog.java
+++ b/src/main/java/com/github/couchmove/pojo/ChangeLog.java
@@ -1,6 +1,7 @@
 package com.github.couchmove.pojo;
 
 import com.couchbase.client.java.Bucket;
+import com.g00fy2.versioncompare.Version;
 import lombok.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -73,6 +74,17 @@ public class ChangeLog extends CouchbaseEntity implements Comparable<ChangeLog> 
 
     @Override
     public int compareTo(@NotNull ChangeLog o) {
-        return version == null ? 0 : version.compareTo(o.version);
+        Version v1 = new Version(this.version);
+        Version v2 = new Version(o.version);
+
+        if (v1.isEqual(v2)) {
+            return 0;
+        }
+
+        if (v1.isHigherThan(v2)) {
+            return 1;
+        }
+
+        return -1;
     }
 }

--- a/src/test/java/com/github/couchmove/pojo/ChangeLogTest.java
+++ b/src/test/java/com/github/couchmove/pojo/ChangeLogTest.java
@@ -1,0 +1,20 @@
+package com.github.couchmove.pojo;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChangeLogTest {
+
+    @Test
+    public void should_compare_version_properly() {
+
+        ChangeLog changeLog1 = ChangeLog.builder().version("0.9").build();
+        ChangeLog changeLog2 = ChangeLog.builder().version("0.11").build();
+        ChangeLog changeLog3 = ChangeLog.builder().version("0.9").build();
+
+        assertEquals(-1, changeLog1.compareTo(changeLog2));
+        assertEquals(1, changeLog2.compareTo(changeLog1));
+        assertEquals(0, changeLog1.compareTo(changeLog3));
+    }
+}


### PR DESCRIPTION
Using Couchmove I ran into an issue with version number with two digits.
The current implementation make v0.9 > v0.11 , which of course it is not. 

I used this lightweight library to implement the fix : https://github.com/G00fY2/version-compare.

Happy to discuss details with you if required.